### PR TITLE
GH-4 | Migrate API calls to `callApi`

### DIFF
--- a/octoprint_SpoolManager/__init__.py
+++ b/octoprint_SpoolManager/__init__.py
@@ -588,7 +588,6 @@ class SpoolmanagerPlugin(
 		pluginNotWorking = connectionErrorResult != None
 		self._sendDataToClient(dict(action = "initalData",
 									selectedSpools = selectedSpoolsAsDicts,
-									isFilamentManagerPluginAvailable = self._filamentManagerPluginImplementation != None,
 									pluginNotWorking = pluginNotWorking
 									))
 		# data for the sidebar
@@ -766,12 +765,6 @@ class SpoolmanagerPlugin(
 				self._settings.set([], self.get_settings_defaults())
 				self._settings.save()
 				return flask.jsonify(self.get_settings_defaults())
-
-			# because of some race conditions, we can't push the initalDate during client-open event. So we provide the settings on request
-			if "additionalSettingsValues" == action:
-				return flask.jsonify({
-					"isFilamentManagerPluginAvailable":self._filamentManagerPluginImplementation != None
-				})
 
 	##~~ SettingsPlugin mixin
 	def get_settings_defaults(self):

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -285,17 +285,15 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.callSelectSpool = callSelectSpool;
 
     /////////////////////////////////////////////////////////////////////////////////////////////////// ALLOWED TO PRINT
-    this.allowedToPrint = function (responseHandler){
-
-        $.ajax({
-            url: this.baseUrl + "plugin/" + this.pluginId + "/allowedToPrint",
-            dataType: "json",
-            contentType: "application/json; charset=UTF-8",
-            type: "GET"
-        }).always(function( data ){
-            responseHandler(data);
-        });
-    }
+    const allowedToPrint = safeAsync(async (spoolDbId) => {
+        return callApi(
+            `allowedToPrint`,
+            {
+                method: "GET",
+            },
+        );
+    });
+    this.allowedToPrint = allowedToPrint;
 
     /////////////////////////////////////////////////////////////////////////////////////////////////// START PRINT CONFIRMED
     this.startPrintConfirmed = function (responseHandler){

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -189,20 +189,18 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.loadDatabaseMetaData = loadDatabaseMetaData;
 
     //////////////////////////////////////////////////////////////////////////////// TEST DatabaseConnection
-    this.testDatabaseConnection = function (databaseSettings, responseHandler){
-        jsonPayload = ko.toJSON(databaseSettings)
+    const testDatabaseConnection = safeAsync(async (databaseSettings) => {
+        const jsonPayload = ko.toJSON(databaseSettings);
 
-        $.ajax({
-            //url: API_BASEURL + "plugin/"+PLUGIN_ID+"/loadPrintJobHistory",
-            url: this.baseUrl + "plugin/" + this.pluginId + "/testDatabaseConnection",
-            dataType: "json",
-            contentType: "application/json; charset=UTF-8",
-            data: jsonPayload,
-            type: "PUT"
-        }).always(function( data ){
-            responseHandler(data);
-        });
-    }
+        return callApi(
+            "testDatabaseConnection",
+            {
+                method: "PUT",
+                body: jsonPayload,
+            },
+        );
+    });
+    this.testDatabaseConnection = testDatabaseConnection;
 
     //////////////////////////////////////////////////////////////////////////////// CONFIRM DatabaseConnectionPoblem
     this.confirmDatabaseProblemMessage = function (responseHandler){

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -254,27 +254,35 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.callDeleteSpool = callDeleteSpool;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////// SELECT Spool-Item
-    this.callSelectSpool = function (toolIndex, databaseId, commitCurrentSpoolValues, responseHandler){
-        if (databaseId == null){
-            databaseId = -1;
+    const callSelectSpool = safeAsync(
+        /**
+         * @param {{
+         *  toolIndex: number;
+         *  spoolDbId?: number;
+         *  shouldCommitCurrentSpoolProgress?: boolean;
+         * }} params
+         */
+        async (params) => {
+            const { toolIndex, spoolDbId, shouldCommitCurrentSpoolProgress } = params;
+
+            const finalSpoolDbId = spoolDbId ?? -1;
+
+            const payload = {
+                databaseId: finalSpoolDbId,
+                toolIndex,
+                commitCurrentSpoolValues: shouldCommitCurrentSpoolProgress
+            }
+
+            return callApi(
+                `selectSpool`,
+                {
+                    method: "PUT",
+                    body: JSON.stringify(payload),
+                },
+            );
         }
-        var payload = {
-            databaseId: databaseId,
-            toolIndex: toolIndex,
-        }
-        if (commitCurrentSpoolValues !== undefined) {
-            payload.commitCurrentSpoolValues = commitCurrentSpoolValues;
-        }
-        $.ajax({
-            url: this.baseUrl + "plugin/" + this.pluginId + "/selectSpool",
-            dataType: "json",
-            contentType: "application/json; charset=UTF-8",
-            data: JSON.stringify(payload),
-            type: "PUT"
-        }).always(function( data ){
-            responseHandler( data );
-        });
-    }
+    );
+    this.callSelectSpool = callSelectSpool;
 
     /////////////////////////////////////////////////////////////////////////////////////////////////// ALLOWED TO PRINT
     this.allowedToPrint = function (responseHandler){

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -290,12 +290,18 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.callDeleteDatabase = callDeleteDatabase;
 
     this.getExportUrl = function(exportType){
-        return _addApiKeyIfNecessary("./plugin/" + this.pluginId + "/exportSpools/" + exportType);
+        const endpointUrl = buildApiUrl(`exportSpools/${exportType}`);
+
+        return _addApiKeyIfNecessary(endpointUrl);
     }
-    this.getSampleCSVUrl = function(){
-        return _addApiKeyIfNecessary("./plugin/" + this.pluginId + "/sampleCSV");
+    this.getSampleCSVUrl = function(exportType){
+        const endpointUrl = buildApiUrl(`sampleCSV`);
+
+        return _addApiKeyIfNecessary(endpointUrl);
     }
     this.getDownloadDatabaseUrl = function(exportType){
-        return _addApiKeyIfNecessary("./plugin/" + this.pluginId + "/downloadDatabase");
+        const endpointUrl = buildApiUrl(`downloadDatabase`);
+
+        return _addApiKeyIfNecessary(endpointUrl);
     }
 }

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -243,9 +243,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             "saveSpool",
             {
                 method: "PUT",
-                headers: {
-                    'Content-Type': "application/json; charset=UTF-8",
-                },
                 body: jsonPayload,
             },
         );

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -66,12 +66,11 @@ const safeAsync = (asyncFn) => {
 };
 
 function SpoolManagerAPIClient(pluginId, baseUrl) {
-
     this.pluginId = pluginId;
     this.baseUrl = baseUrl;
 
     // see https://gomakethings.com/how-to-build-a-query-string-from-an-object-with-vanilla-js/
-    var _buildRequestQuery = function (data) {
+    const _buildRequestQuery = function (data) {
         // If the data is already a string, return it as-is
         if (typeof (data) === 'string') return data;
 
@@ -91,19 +90,11 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
 
     };
 
-    var _addApiKeyIfNecessary = function(urlContext){
+    const _addApiKeyIfNecessary = function(urlContext) {
         if (UI_API_KEY){
             urlContext = urlContext + "?apikey=" + UI_API_KEY;
         }
         return urlContext;
-    }
-
-    this.getExportUrl = function(exportType){
-        return _addApiKeyIfNecessary("./plugin/" + this.pluginId + "/exportSpools/" + exportType);
-    }
-
-    this.getSampleCSVUrl = function(){
-        return _addApiKeyIfNecessary("./plugin/" + this.pluginId + "/sampleCSV");
     }
 
     const buildApiUrl = (url) => {
@@ -167,7 +158,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
         });
     };
 
-    //////////////////////////////////////////////////////////////////////////////// LOAD DatabaseMetaData
     const loadDatabaseMetaData = safeAsync(async () => {
         return callApi(
             "loadDatabaseMetaData",
@@ -176,9 +166,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             },
         );
     });
-    this.loadDatabaseMetaData = loadDatabaseMetaData;
-
-    //////////////////////////////////////////////////////////////////////////////// TEST DatabaseConnection
     const testDatabaseConnection = safeAsync(async (databaseSettings) => {
         const jsonPayload = ko.toJSON(databaseSettings);
 
@@ -190,9 +177,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             },
         );
     });
-    this.testDatabaseConnection = testDatabaseConnection;
-
-    //////////////////////////////////////////////////////////////////////////////// CONFIRM DatabaseConnectionPoblem
     const confirmDatabaseProblemMessage = safeAsync(async () => {
         return callApi(
             "confirmDatabaseProblemMessage",
@@ -201,10 +185,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             },
         );
     });
-    this.confirmDatabaseProblemMessage = confirmDatabaseProblemMessage;
-
-
-    //////////////////////////////////////////////////////////////////////////////// LOAD FILTERED/SORTED PrintJob-Items
     const callLoadSpoolsByQuery = safeAsync(async (tableQuery) => {
         const queryParams = _buildRequestQuery(tableQuery);
 
@@ -215,10 +195,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             },
         );
     });
-    this.callLoadSpoolsByQuery = callLoadSpoolsByQuery;
-
-
-    //////////////////////////////////////////////////////////////////////////////////////////////////// SAVE Spool-Item
     const callSaveSpool = safeAsync(async (spoolItem) => {
         const jsonPayload = ko.toJSON(spoolItem);
 
@@ -230,9 +206,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             },
         );
     });
-    this.callSaveSpool = callSaveSpool;
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////// DELETE Spool-Item
     const callDeleteSpool = safeAsync(async (spoolDbId) => {
         return callApi(
             `deleteSpool/${spoolDbId}`,
@@ -241,9 +214,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             },
         );
     });
-    this.callDeleteSpool = callDeleteSpool;
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////// SELECT Spool-Item
     const callSelectSpool = safeAsync(
         /**
          * @param {{
@@ -272,9 +242,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             );
         }
     );
-    this.callSelectSpool = callSelectSpool;
-
-    /////////////////////////////////////////////////////////////////////////////////////////////////// ALLOWED TO PRINT
     const allowedToPrint = safeAsync(async () => {
         return callApi(
             `allowedToPrint`,
@@ -283,9 +250,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             },
         );
     });
-    this.allowedToPrint = allowedToPrint;
-
-    /////////////////////////////////////////////////////////////////////////////////////////////////// START PRINT CONFIRMED
     const startPrintConfirmed = safeAsync(async () => {
         return callApi(
             `startPrintConfirmed`,
@@ -294,9 +258,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             },
         );
     });
-    this.startPrintConfirmed = startPrintConfirmed;
-
-    //////////////////////////////////////////////////////////////////////////////////////////////////// DELETE Database
     const callDeleteDatabase = safeAsync(
         /**
          * @param {{
@@ -316,9 +277,24 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             );
         }
     );
+
+    this.loadDatabaseMetaData = loadDatabaseMetaData;
+    this.testDatabaseConnection = testDatabaseConnection;
+    this.confirmDatabaseProblemMessage = confirmDatabaseProblemMessage;
+    this.callLoadSpoolsByQuery = callLoadSpoolsByQuery;
+    this.callSaveSpool = callSaveSpool;
+    this.callDeleteSpool = callDeleteSpool;
+    this.callSelectSpool = callSelectSpool;
+    this.allowedToPrint = allowedToPrint;
+    this.startPrintConfirmed = startPrintConfirmed;
     this.callDeleteDatabase = callDeleteDatabase;
 
-    ////////////////////////////////////////////////////////////////////////////////////////////////// DOWNLOAD Database
+    this.getExportUrl = function(exportType){
+        return _addApiKeyIfNecessary("./plugin/" + this.pluginId + "/exportSpools/" + exportType);
+    }
+    this.getSampleCSVUrl = function(){
+        return _addApiKeyIfNecessary("./plugin/" + this.pluginId + "/sampleCSV");
+    }
     this.getDownloadDatabaseUrl = function(exportType){
         return _addApiKeyIfNecessary("./plugin/" + this.pluginId + "/downloadDatabase");
     }

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -152,15 +152,16 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
         });
     }
     //////////////////////////////////////////////////////////////////////////////// LOAD DatabaseMetaData
-    this.loadDatabaseMetaData = function (responseHandler){
-        var urlToCall = this.baseUrl + "plugin/"+this.pluginId+"/loadDatabaseMetaData";
-        $.ajax({
-            url: urlToCall,
-            type: "GET"
-        }).always(function( data ){
-            responseHandler(data)
-        });
-    }
+    const loadDatabaseMetaData = safeAsync(async (spoolItem) => {
+        return callApi(
+            "loadDatabaseMetaData",
+            {
+                method: "GET",
+            },
+        );
+    });
+    this.loadDatabaseMetaData = loadDatabaseMetaData;
+
     //////////////////////////////////////////////////////////////////////////////// TEST DatabaseConnection
     this.testDatabaseConnection = function (databaseSettings, responseHandler){
         jsonPayload = ko.toJSON(databaseSettings)

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -69,29 +69,24 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.pluginId = pluginId;
     this.baseUrl = baseUrl;
 
-    // see https://gomakethings.com/how-to-build-a-query-string-from-an-object-with-vanilla-js/
     const _buildRequestQuery = function (data) {
-        // If the data is already a string, return it as-is
-        if (typeof (data) === 'string') return data;
-
-        // Create a query array to hold the key/value pairs
-        var query = [];
-
-        // Loop through the data object
-        for (var key in data) {
-            if (data.hasOwnProperty(key)) {
-
-                // Encode each key and value, concatenate them into a string, and push them to the array
-                query.push(encodeURIComponent(key) + '=' + encodeURIComponent(data[key]));
-            }
+        if (typeof (data) === 'string') {
+            return data;
         }
-        // Join each item in the array with a `&` and return the resulting string
-        return query.join('&');
 
+        return Object
+            .entries(data)
+            .map(([ key, value ]) => {
+                const encodedKey = encodeURIComponent(key);
+                const encodedValue = encodeURIComponent(value);
+
+                return `${encodedKey}=${encodedValue}`;
+            })
+            .join('&');
     };
 
-    const _addApiKeyIfNecessary = function(urlContext) {
-        if (UI_API_KEY){
+    const _addApiKeyIfNecessary = function (urlContext) {
+        if (UI_API_KEY) {
             urlContext = urlContext + "?apikey=" + UI_API_KEY;
         }
         return urlContext;

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -203,17 +203,15 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.testDatabaseConnection = testDatabaseConnection;
 
     //////////////////////////////////////////////////////////////////////////////// CONFIRM DatabaseConnectionPoblem
-    this.confirmDatabaseProblemMessage = function (responseHandler){
-        $.ajax({
-            //url: API_BASEURL + "plugin/"+PLUGIN_ID+"/loadPrintJobHistory",
-            url: this.baseUrl + "plugin/" + this.pluginId + "/confirmDatabaseProblemMessage",
-            dataType: "json",
-            contentType: "application/json; charset=UTF-8",
-            type: "PUT"
-        }).always(function( data ){
-            responseHandler(data);
-        });
-    }
+    const confirmDatabaseProblemMessage = safeAsync(async () => {
+        return callApi(
+            "confirmDatabaseProblemMessage",
+            {
+                method: "PUT",
+            },
+        );
+    });
+    this.confirmDatabaseProblemMessage = confirmDatabaseProblemMessage;
 
 
     //////////////////////////////////////////////////////////////////////////////// LOAD FILTERED/SORTED PrintJob-Items

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -215,20 +215,17 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
 
 
     //////////////////////////////////////////////////////////////////////////////// LOAD FILTERED/SORTED PrintJob-Items
-    this.callLoadSpoolsByQuery = function (tableQuery, responseHandler){
-        query = _buildRequestQuery(tableQuery);
-        urlToCall = this.baseUrl + "plugin/"+this.pluginId+"/loadSpoolsByQuery?"+query;
-        $.ajax({
-            //url: API_BASEURL + "plugin/"+PLUGIN_ID+"/loadPrintJobHistory",
-            url: urlToCall,
-            type: "GET"
-        }).always(function( data ){
-            responseHandler(data)
-            //shoud be done by the server to make sure the server is informed countdownDialog.modal('hide');
-            //countdownDialog.modal('hide');
-            //countdownCircle = null;
-        });
-    }
+    const callLoadSpoolsByQuery = safeAsync(async (tableQuery) => {
+        const queryParams = _buildRequestQuery(tableQuery);
+
+        return callApi(
+            `loadSpoolsByQuery?${queryParams}`,
+            {
+                method: "GET",
+            },
+        );
+    });
+    this.callLoadSpoolsByQuery = callLoadSpoolsByQuery;
 
 
     //////////////////////////////////////////////////////////////////////////////////////////////////// SAVE Spool-Item

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -37,6 +37,7 @@ const createFailure = (error) => {
 };
 
 const ASYNC_FN_FAIL_ERROR = "ASYNC_FN_FAILED";
+const REQUEST_FAILED_ERROR = "REQUEST_FAILED";
 
 /**
  * @template {unknown[]} AsyncArgs
@@ -111,14 +112,8 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
 
     const callApi = async (url, options) => {
         const endpointUrl = buildApiUrl(url);
+
         const request = await fetch(endpointUrl, options);
-
-        if (!request.ok) {
-            return createFailure({
-                type: "REQUEST_FAILED",
-            });
-        }
-
         const response = await ((async () => {
             if (request.headers.get('Content-Type') !== 'application/json') {
                 return;
@@ -135,6 +130,20 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
                 return;
             }
         }))();
+
+        if (!request.ok) {
+            return createFailure({
+                /**
+                 * @type {typeof REQUEST_FAILED_ERROR}
+                 */
+                type: REQUEST_FAILED_ERROR,
+                /**
+                 * @type true
+                 */
+                isRequestFailure: true,
+                response,
+            });
+        }
 
         return createSuccess({
             response,

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -285,7 +285,7 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.callSelectSpool = callSelectSpool;
 
     /////////////////////////////////////////////////////////////////////////////////////////////////// ALLOWED TO PRINT
-    const allowedToPrint = safeAsync(async (spoolDbId) => {
+    const allowedToPrint = safeAsync(async () => {
         return callApi(
             `allowedToPrint`,
             {

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -152,7 +152,7 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
         });
     }
     //////////////////////////////////////////////////////////////////////////////// LOAD DatabaseMetaData
-    const loadDatabaseMetaData = safeAsync(async (spoolItem) => {
+    const loadDatabaseMetaData = safeAsync(async () => {
         return callApi(
             "loadDatabaseMetaData",
             {

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -296,17 +296,15 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.allowedToPrint = allowedToPrint;
 
     /////////////////////////////////////////////////////////////////////////////////////////////////// START PRINT CONFIRMED
-    this.startPrintConfirmed = function (responseHandler){
-
-        $.ajax({
-            url: this.baseUrl + "plugin/" + this.pluginId + "/startPrintConfirmed",
-            dataType: "json",
-            contentType: "application/json; charset=UTF-8",
-            type: "GET"
-        }).always(function( data ){
-            responseHandler(data);
-        });
-    }
+    const startPrintConfirmed = safeAsync(async () => {
+        return callApi(
+            `startPrintConfirmed`,
+            {
+                method: "GET",
+            },
+        );
+    });
+    this.startPrintConfirmed = startPrintConfirmed;
 
     //////////////////////////////////////////////////////////////////////////////////////////////////// DELETE Database
     this.callDeleteDatabase = function(databaseType, databaseSettings, responseHandler){

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -307,22 +307,26 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.startPrintConfirmed = startPrintConfirmed;
 
     //////////////////////////////////////////////////////////////////////////////////////////////////// DELETE Database
-    this.callDeleteDatabase = function(databaseType, databaseSettings, responseHandler){
-        jsonPayload = ko.toJSON(databaseSettings)
-        $.ajax({
-            //url: API_BASEURL + "plugin/"+PLUGIN_ID+"/loadPrintJobHistory",
-            url: this.baseUrl + "plugin/"+this.pluginId+"/deleteDatabase/"+databaseType,
-            dataType: "json",
-            contentType: "application/json; charset=UTF-8",
-            data: jsonPayload,
-            type: "POST"
-        }).always(function( data ){
-            responseHandler(data)
-            //shoud be done by the server to make sure the server is informed countdownDialog.modal('hide');
-            //countdownDialog.modal('hide');
-            //countdownCircle = null;
-        });
-    }
+    const callDeleteDatabase = safeAsync(
+        /**
+         * @param {{
+         *  databaseType: string;
+         *  databaseSettings: unknown;
+         * }} params
+         */
+        async (params) => {
+            const { databaseType, databaseSettings } = params;
+
+            return callApi(
+                `deleteDatabase/${databaseType}`,
+                {
+                    method: "POST",
+                    body: ko.toJSON(databaseSettings),
+                },
+            );
+        }
+    );
+    this.callDeleteDatabase = callDeleteDatabase;
 
     ////////////////////////////////////////////////////////////////////////////////////////////////// DOWNLOAD Database
     this.getDownloadDatabaseUrl = function(exportType){

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -109,11 +109,28 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     const buildApiUrl = (url) => {
         return `${this.baseUrl}plugin/${this.pluginId}/${url}`;
     };
+    const buildFetchOptions = (options) => {
+        const methodsWithBody = [ "POST", "PUT", "PATCH" ];
+
+        const fetchOptions = {
+            ...options,
+        };
+
+        if (methodsWithBody.includes((options.method ?? "GET").toUpperCase())) {
+            fetchOptions.headers = {
+                'Content-Type': "application/json; charset=UTF-8",
+                ...(fetchOptions.headers ?? {}),
+            };
+        }
+
+        return fetchOptions;
+    };
 
     const callApi = async (url, options) => {
         const endpointUrl = buildApiUrl(url);
+        const fetchOptions = buildFetchOptions(options);
 
-        const request = await fetch(endpointUrl, options);
+        const request = await fetch(endpointUrl, fetchOptions);
         const response = await ((async () => {
             if (request.headers.get('Content-Type') !== 'application/json') {
                 return;

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -167,16 +167,6 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
         });
     };
 
-    //////////////////////////////////////////////////////////////////////////////// LOAD AdditionalSettingsValues
-    this.callAdditionalSettings = function (responseHandler){
-        var urlToCall = this.baseUrl + "api/plugin/"+this.pluginId+"?action=additionalSettingsValues";
-        $.ajax({
-            url: urlToCall,
-            type: "GET"
-        }).always(function( data ){
-            responseHandler(data)
-        });
-    }
     //////////////////////////////////////////////////////////////////////////////// LOAD DatabaseMetaData
     const loadDatabaseMetaData = safeAsync(async () => {
         return callApi(

--- a/octoprint_SpoolManager/static/js/SpoolManager-DatabaseConnectionProblemDialog.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-DatabaseConnectionProblemDialog.js
@@ -55,9 +55,7 @@ function DatabaseConnectionProblemDialog(){
 
     /////////////////////////////////////////////////////////////////////////////////////////////////// CLOSE
     self.closeDialog  = function(){
-        self.apiClient.confirmDatabaseProblemMessage(function(response){
-            // nothing special to do
-        });
+        void self.apiClient.confirmDatabaseProblemMessage();
         self.problemDialog.modal('hide');
         self.isVisible = false;
         self.closeDialogHandler();

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -828,9 +828,9 @@ $(function() {
         ///////////////////////////////////////////////////////////////////////////////////////// OCTOPRINT PRINT-BUTTON
         const origStartPrintFunction = self.printerStateViewModel.print;
         const newStartPrintFunction = async function confirmSpoolSelectionBeforeStartPrint() {
-            const queryResult = await self.apiClient.allowedToPrint();
+            const prePrintChecksQueryResult = await self.apiClient.allowedToPrint();
 
-            if (!queryResult.isSuccess) {
+            if (!prePrintChecksQueryResult.isSuccess) {
                 return self.showPopUp(
                     "error",
                     'Start print pre-checks',
@@ -845,7 +845,7 @@ $(function() {
                 toolOffsetEnabled,
                 bedOffsetEnabled,
                 enclosureOffsetEnabled,
-            } = queryResult.payload.response;
+            } = prePrintChecksQueryResult.payload.response;
 
             const printWarnings = (
                 metaOrAttributesMissing
@@ -926,9 +926,18 @@ $(function() {
                 }
             }
 
-            self.apiClient.startPrintConfirmed(() => {
-                origStartPrintFunction();
-            });
+            const startPrintQueryResult = await self.apiClient.startPrintConfirmed();
+
+            if (!startPrintQueryResult.isSuccess) {
+                return self.showPopUp(
+                    "error",
+                    'Start print setup',
+                    'An unknown error occurred while requesting data',
+                    true,
+                );
+            }
+
+            origStartPrintFunction();
         };
         self.printerStateViewModel.print = newStartPrintFunction;
 

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -272,22 +272,29 @@ $(function() {
 
         $("#spoolmanger-settings-tab")
             .find('a[data-toggle="tab"]')
-            .on('shown', function (evt) {
+            .on('shown', async function (evt) {
                 const activatedTab = evt.target.hash;
-                const prevTab = evt.relatedTarget.hash;
 
-                if ("#tab-spool-Storage" != activatedTab) {
+                if (activatedTab != "#tab-spool-Storage") {
                     return;
                 }
 
                 self.resetDatabaseMessages()
                 self.showLocalBusyIndicator(true);
                 self.showExternalBusyIndicator(true);
-                self.apiClient.loadDatabaseMetaData(function(responseData) {
-                    self.handleDatabaseMetaDataResponse(responseData);
-                    self.showLocalBusyIndicator(false);
-                    self.showExternalBusyIndicator(false);
-                });
+
+                const dbMetaDataResult = await self.apiClient.loadDatabaseMetaData();
+
+                if (!dbMetaDataResult.isSuccess) {
+                    // TODO: Error handling
+                    return;
+                }
+
+                const responseData = dbMetaDataResult.payload.response;
+
+                self.handleDatabaseMetaDataResponse(responseData);
+                self.showLocalBusyIndicator(false);
+                self.showExternalBusyIndicator(false);
             });
 
         self.isFilamentManagerPluginAvailable = ko.observable(false);

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -286,7 +286,7 @@ $(function() {
                 const dbMetaDataResult = await self.apiClient.loadDatabaseMetaData();
 
                 if (!dbMetaDataResult.isSuccess) {
-                    return managerViewModel.showPopUp(
+                    return self.showPopUp(
                         "error",
                         'Load storage metadata',
                         'An unknown error occurred while loading data',

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -244,16 +244,31 @@ $(function() {
             }
         }
 
-        self.testDatabaseConnection = function() {
+        self.testDatabaseConnection = async function() {
             self.resetDatabaseMessages()
             self.showExternalBusyIndicator(true);
 
             const databaseSettings = self.buildDatabaseSettings();
 
-            self.apiClient.testDatabaseConnection(databaseSettings, function(responseData) {
-                self.handleDatabaseMetaDataResponse(responseData);
-                self.showExternalBusyIndicator(false);
-            });
+            const testResult = await self.apiClient.testDatabaseConnection(databaseSettings);
+
+            if (!testResult.isSuccess && testResult.error.type !== "REQUEST_FAILED") {
+                return self.showPopUp(
+                    "error",
+                    'Test database connection',
+                    'An unknown error occurred while performing a request',
+                    true,
+                );
+            }
+
+            const responseData = (
+                testResult.isSuccess
+                    ? testResult.payload.response
+                    : testResult.error.response
+            );
+
+            self.handleDatabaseMetaDataResponse(responseData);
+            self.showExternalBusyIndicator(false);
         }
 
         self.deleteDatabaseAction = function(databaseType) {

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -206,12 +206,14 @@ $(function() {
 
         self.handleDatabaseMetaDataResponse = function(metaDataResponse) {
             const metadata = metaDataResponse.metadata;
+            const requestError = metaDataResponse.error;
 
-            if (metadata == null) {
+            if (!metadata && !requestError) {
                 return;
             }
 
-            const errorMessage = metadata.errorMessage;
+            const errorMessage = (metadata && metadata.errorMessage) || requestError;
+
             if (errorMessage != null && errorMessage.length != 0) {
                 self.showDatabaseErrorMessage(true);
                 self.databaseErrorMessage(errorMessage);

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -330,8 +330,6 @@ $(function() {
                 self.showExternalBusyIndicator(false);
             });
 
-        self.isFilamentManagerPluginAvailable = ko.observable(false);
-
         // - Import CSV
         self.csvFileUploadName = ko.observable();
         self.csvImportInProgress = ko.observable(false);
@@ -1093,14 +1091,6 @@ $(function() {
 // testing            self.spoolDialog.showDialog(null, handleSpoolDialogClose);
         }
 
-        self.onSettingsShown = function() {
-            if (self.isFilamentManagerPluginAvailable() == false){
-                self.apiClient.callAdditionalSettings(function(responseData) {
-                    self.isFilamentManagerPluginAvailable(responseData.isFilamentManagerPluginAvailable);
-                });
-            }
-        }
-
         // receive data from server
         self.onDataUpdaterPluginMessage = function (plugin, data) {
             if (plugin != PLUGIN_ID) {
@@ -1110,7 +1100,6 @@ $(function() {
             if ("initalData" == data.action){
 
                 self.pluginNotWorking(data.pluginNotWorking);
-                self.isFilamentManagerPluginAvailable(data.isFilamentManagerPluginAvailable);
                 var spoolsData = data.selectedSpools,
                     slot, spoolData, spoolItem;
                 for(var i=0; i<self.selectedSpoolsForSidebar().length; i++) {

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -286,8 +286,12 @@ $(function() {
                 const dbMetaDataResult = await self.apiClient.loadDatabaseMetaData();
 
                 if (!dbMetaDataResult.isSuccess) {
-                    // TODO: Error handling
-                    return;
+                    return managerViewModel.showPopUp(
+                        "error",
+                        'Load storage metadata',
+                        'An unknown error occurred while loading data',
+                        true,
+                    );
                 }
 
                 const responseData = dbMetaDataResult.payload.response;

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -273,7 +273,7 @@ $(function() {
             self.showExternalBusyIndicator(false);
         }
 
-        self.deleteDatabaseAction = function(databaseType) {
+        self.deleteDatabaseAction = async function(databaseType) {
             const confirmationResult = confirm("Do you really want to delete all SpoolManager data?");
 
             if (!confirmationResult) {
@@ -282,9 +282,21 @@ $(function() {
 
             const databaseSettings = self.buildDatabaseSettings();
 
-            self.apiClient.callDeleteDatabase(databaseType, databaseSettings, function(responseData) {
-                self.spoolItemTableHelper.reloadItems();
+            const requestResult = await self.apiClient.callDeleteDatabase({
+                databaseType,
+                databaseSettings,
             });
+
+            if (!requestResult.isSuccess) {
+                return self.showPopUp(
+                    "error",
+                    'Recreate Database',
+                    'An unknown error occurred while performing a request',
+                    true,
+                );
+            }
+
+            self.spoolItemTableHelper.reloadItems();
         };
 
         $("#spoolmanger-settings-tab")

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -554,8 +554,12 @@ $(function() {
             const loadResult = await self.apiClient.callLoadSpoolsByQuery(fetchSpoolsQueryParams);
 
             if (!loadResult.isSuccess) {
-                // TODO: Error handling
-                return;
+                return self.showPopUp(
+                    "error",
+                    'Load sidebar data',
+                    'An unknown error occurred while loading data',
+                    true,
+                );
             }
 
             const responseData = loadResult.payload.response;
@@ -741,8 +745,12 @@ $(function() {
                 const loadResult = await self.apiClient.callLoadSpoolsByQuery(tableQuery);
 
                 if (!loadResult.isSuccess) {
-                    // TODO: Error handling
-                    return;
+                    return self.showPopUp(
+                        "error",
+                        'Load spools list',
+                        'An unknown error occurred while loading data',
+                        true,
+                    );
                 }
 
                 const responseData = loadResult.payload.response;

--- a/octoprint_SpoolManager/templates/SpoolManager_settings.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_settings.jinja2
@@ -263,12 +263,6 @@ FPE;	2.16
                         <span><b>SpoolManager Database</b>: Export all data as <a target="_newTab" href="#" data-bind="attr: {href: $root.apiClient.getExportUrl('CSV')}">CSV-File</a></span>
                     </div>
                 </div>
-                <div class="control-group" data-bind="visible: isFilamentManagerPluginAvailable">
-                    <div class="controls">
-                        <span><b>Legacy: Filament Manager Database</b>: Export all data as <a target="_newTab" href="#" data-bind="attr: {href: $root.apiClient.getExportUrl('legacyFilamentManager'), css: {disabled: !$root.apiClient.getExportUrl('legacyFilamentManager')}}">CSV-File</a></span>
-                    </div>
-                </div>
-
 
                 <h3>Import</h3>
 


### PR DESCRIPTION
Closes #4 

Changelog:
- [x] API calls migration to `callApi` (and add basic error handling to call site)
  - [x] `callAdditionalSettings` (removed)
  - [x] `loadDatabaseMetaData`
  - [x] `testDatabaseConnection`
  - [x] `confirmDatabaseProblemMessage`
  - [x] `callLoadSpoolsByQuery`
  - [x] `callSaveSpool` (already done)
  - [x] `callDeleteSpool` (already done)
  - [x] `callSelectSpool`
  - [x] `allowedToPrint`
  - [x] `startPrintConfirmed`
  - [x] `callDeleteDatabase`
- [x] Investigate `_buildRequestQuery` simplification
- [x] `callApi` should better handle error responses
- [x] `callApi` should automatically detect "contentful" requests and attach appropriate headers