### PR TITLE
GH-6 | Lazy load sidebar's spools

### DIFF
--- a/octoprint_SpoolManager/__init__.py
+++ b/octoprint_SpoolManager/__init__.py
@@ -783,6 +783,7 @@ class SpoolmanagerPlugin(
 		settings[SettingsKeys.SETTINGS_KEY_WARN_IF_FILAMENT_NOT_ENOUGH] = True
 		settings[SettingsKeys.SETTINGS_KEY_CURRENCY_SYMBOL] = "€"
 		settings[SettingsKeys.SETTINGS_KEY_SAFETY_LENGTH] = 0
+		settings[SettingsKeys.SETTINGS_KEY_PERFORMANCE_LAZY_LOAD_SPOOL_SELECTOR_DATA] = False
 
 		## QR-Code
 		settings[SettingsKeys.SETTINGS_KEY_QR_CODE_ENABLED] = True

--- a/octoprint_SpoolManager/api/SpoolManagerAPI.py
+++ b/octoprint_SpoolManager/api/SpoolManagerAPI.py
@@ -909,10 +909,6 @@ class SpoolManagerAPI(octoprint.plugin.BlueprintPlugin):
 		# 	"colors": ["", "#123", "#456"],
 		# 	"labels": ["", "good", "bad"]
 		# }
-		selectedSpoolsAsDicts = [
-			(None if selectedSpool is None else Transformer.transformSpoolModelToDict(selectedSpool))
-			for selectedSpool in self.loadSelectedSpools()
-		]
 
 		return flask.jsonify({
 								# "databaseConnectionProblem": self._databaseManager.isConnected() == False,
@@ -920,6 +916,20 @@ class SpoolManagerAPI(octoprint.plugin.BlueprintPlugin):
 								"catalogs": catalogs,
 								"totalItemCount": totalItemCount,
 								"allSpools": allSpoolsAsDict,
+							})
+
+	##################################################################################################   LOAD SELECTED SPOOLS
+	@octoprint.plugin.BlueprintPlugin.route("/loadSelectedSpools", methods=["GET"])
+	def handleLoadSelectedSpools(self):
+
+		self._logger.debug("API Load selected spools")
+
+		selectedSpoolsAsDicts = [
+			(None if selectedSpool is None else Transformer.transformSpoolModelToDict(selectedSpool))
+			for selectedSpool in self.loadSelectedSpools()
+		]
+
+		return flask.jsonify({
 								"selectedSpools": selectedSpoolsAsDicts
 							})
 

--- a/octoprint_SpoolManager/common/SettingsKeys.py
+++ b/octoprint_SpoolManager/common/SettingsKeys.py
@@ -15,6 +15,8 @@ class SettingsKeys():
 
 	SETTINGS_KEY_SAFETY_LENGTH = "safetyLength" # in mm e.g. ptfe-tube
 
+	SETTINGS_KEY_PERFORMANCE_LAZY_LOAD_SPOOL_SELECTOR_DATA = "performanceLazyLoadSpoolSelectorData"
+
 	## QR - Code
 	SETTINGS_KEY_QR_CODE_ENABLED = "qrCodeEnabled"
 	SETTINGS_KEY_QR_CODE_USE_URL_PREFIX = "qrCodeUseURLPrefix"

--- a/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager-APIClient.js
@@ -180,6 +180,14 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
             },
         );
     });
+    const callLoadSelectedSpools = safeAsync(async () => {
+        return callApi(
+            "loadSelectedSpools",
+            {
+                method: "GET",
+            },
+        );
+    });
     const callLoadSpoolsByQuery = safeAsync(async (tableQuery) => {
         const queryParams = _buildRequestQuery(tableQuery);
 
@@ -276,6 +284,7 @@ function SpoolManagerAPIClient(pluginId, baseUrl) {
     this.loadDatabaseMetaData = loadDatabaseMetaData;
     this.testDatabaseConnection = testDatabaseConnection;
     this.confirmDatabaseProblemMessage = confirmDatabaseProblemMessage;
+    this.callLoadSelectedSpools = callLoadSelectedSpools;
     this.callLoadSpoolsByQuery = callLoadSpoolsByQuery;
     this.callSaveSpool = callSaveSpool;
     this.callDeleteSpool = callDeleteSpool;

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -766,7 +766,9 @@ $(function() {
             });
 
             if (!hasInitializedSpoolsSelector) {
-                loadSpoolSelectorData();
+                loadSpoolSelectorData().then(() => {
+                    self.selectionSpoolDialog.modal('layout');
+                });
             }
 
             self.sidebarSelectSpoolModalSpoolItem(spoolItem);

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -78,7 +78,7 @@ $(function() {
             // Initialize localStorage with default value
             localStorage[storageKey] = `${DEFAULT_TABLE_PAGE_SIZE}`;
         } else {
-            viewModel.spoolItemTableHelper.selectedPageSize(localStorage[storageKey]);
+            viewModel.spoolItemTableHelper.selectedPageSize(Number(localStorage[storageKey]));
         }
 
         viewModel.spoolItemTableHelper.selectedPageSize.subscribe(function(newValue) {

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -1109,7 +1109,9 @@ $(function() {
             });
 
             // needed after the tool-count is changed
-            self.settingsViewModel.printerProfiles.currentProfileData.subscribe(self.loadSpoolsForSidebar);
+            self.settingsViewModel.printerProfiles.currentProfileData.subscribe(() => {
+                updateAvailableSpoolSlots();
+            });
         }
 
         self.onAfterBinding = function() {

--- a/octoprint_SpoolManager/templates/SpoolManager_settings.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_settings.jinja2
@@ -57,6 +57,16 @@
                         </div>
                     </div>
                 </div>
+
+                <hr/>
+                <h4>Performance</h4>
+                <div class="control-group">
+                    <div class="controls">
+                        <label class="checkbox">
+                            <input type="checkbox" data-bind="checked: pluginSettings.performanceLazyLoadSpoolSelectorData" > EXPERIMENTAL: Lazy load spool selector's data. Allows to lessen performance stress on initial OctoPrint load, useful for less powerful machines.
+                        </label>
+                    </div>
+                </div>
 <!--
                 <h4>Default Catalogs</h4>
                 <div>


### PR DESCRIPTION
Closes #6

Changelog:
- [x] Separate fetching current spool(s) selection from general spools list fetcher
- [x] Add an option to opt-in into "spool selector's data lazy loading"
- [x] Fix loading page size from Local storage