### PR TITLE
GH-14 | Prevent unnecessary loadSpoolsByQuery initial calls

### DIFF
--- a/octoprint_SpoolManager/static/js/TableItemHelper.js
+++ b/octoprint_SpoolManager/static/js/TableItemHelper.js
@@ -177,16 +177,16 @@ function TableItemHelper(loadItemsFunction, defaultPageSize, defaultSortColumn, 
         }
     });
 
-    self._evalFilterLabel = function(allArray, selectionArray){
-        // check if all selected
-        var selectionCount = 0
-        for (let item of allArray) {
-            if (selectionArray.indexOf(item) != -1){
-                selectionCount++;
-            }
-        }
-        var allSelected = selectionCount ==  allArray.length
-        return allSelected == true ? "all" : selectionArray.length;
+    self._evalFilterLabel = function(allArray, selectionArray) {
+        const areAllExistingSelected = allArray.every((element) => {
+            return selectionArray.includes(element);
+        });
+
+        return (
+            areAllExistingSelected
+                ? "all"
+                : selectionArray.length
+        );
     };
 
     // ################################################################################################ public functions
@@ -276,36 +276,35 @@ function TableItemHelper(loadItemsFunction, defaultPageSize, defaultSortColumn, 
     }
 
     self.isFilterSelected = function(filterName) {
-        // return self.selectedFilterName() == filterName;
         return self.selectedFilterNameArrayKO().includes(filterName);
     };
 
-    self.buildFilterLabel = function(filterLabelName){
-        // spoolItemTableHelper.selectedColorsForFilter().length == spoolItemTableHelper.allColors().length ? 'all' : spoolItemTableHelper.selectedColorsForFilter().length
-        // to detecting all, we can't use the length, because if just the color is changed then length is still true
-        // so we need to compare each value
-        if ("color" == filterLabelName){
-            var selectionArray = self.selectedColorsForFilter(); // array of colorIds [#ffa500;orange, #ffffff;white]
-            var allColorArray = self.allColors(); // array of object with 'colorId=#ffa500;orange','color=#ffa500','colorName="orange"'
-            // check if all colors selected
-            var selectionCount = 0
-            for (let colorItem of allColorArray) {
-                var colorId = colorItem.colorId;
-                if (selectionArray.indexOf(colorId) != -1){
-                    selectionCount++;
-                }
-            }
-            var allColorsSelected = selectionCount ==  allColorArray.length
-            return allColorsSelected == true ? "all" : self.selectedColorsForFilter().length;
+    self.buildFilterLabel = function(filterLabelName) {
+        /**
+         * Check if all existing colors in the catalog are in the selected list.
+         * This way we prevent positives eg. when selected list contains something that no longer exist,
+         * but the length of both lists are still the same (eg. because of a new color).
+         */
+        if ("color" == filterLabelName) {
+            return self._evalFilterLabel(
+                self.allColors().map((existingColor) => existingColor.colorId),
+                self.selectedColorsForFilter(),
+            );
         }
-        if ("material" == filterLabelName){
-            return self._evalFilterLabel(self.allMaterials(), self.selectedMaterialsForFilter());
+        if ("material" == filterLabelName) {
+            return self._evalFilterLabel(
+                self.allMaterials(),
+                self.selectedMaterialsForFilter(),
+            );
         }
-        if ("vendor" == filterLabelName){
-            return self._evalFilterLabel(self.allVendors(), self.selectedVendorsForFilter());
+        if ("vendor" == filterLabelName) {
+            return self._evalFilterLabel(
+                self.allVendors(),
+                self.selectedVendorsForFilter(),
+            );
         }
 
-        return "not defined:" + filterLabelName;
+        return "unknown:" + filterLabelName;
     }
 
     // ############################################## PAGING

--- a/octoprint_SpoolManager/static/js/TableItemHelper.js
+++ b/octoprint_SpoolManager/static/js/TableItemHelper.js
@@ -194,17 +194,13 @@ function TableItemHelper(loadItemsFunction, defaultPageSize, defaultSortColumn, 
         self._loadItems();
     }
 
-    self.updateCatalogs = function(catalogs){
+    self.updateCatalogs = function(newCatalogs) {
         isUpdatingCatalogs = true;
 
-        self.allCatalogs = catalogs;
-        var materialsCatalog = self.allCatalogs["materials"];
-        var vendorsCatalog = self.allCatalogs["vendors"];
-        var colorsCatalog = self.allCatalogs["colors"];
-
-        self.allMaterials(materialsCatalog);
-        self.allVendors(vendorsCatalog);
-        self.allColors(colorsCatalog);
+        self.allCatalogs = newCatalogs;
+        self.allMaterials(self.allCatalogs.materials);
+        self.allVendors(self.allCatalogs.vendors);
+        self.allColors(self.allCatalogs.colors);
 
         if (self.showAllMaterialsForFilter()) {
             handleSelectAllMaterials();
@@ -239,7 +235,7 @@ function TableItemHelper(loadItemsFunction, defaultPageSize, defaultSortColumn, 
             if ("desc" == self.sortOrder()){
                 self.sortOrder("asc");
             } else {
-               self.sortOrder("desc");
+                self.sortOrder("desc");
             }
         } else {
             self.sortColumn(newSortColumn);
@@ -255,7 +251,7 @@ function TableItemHelper(loadItemsFunction, defaultPageSize, defaultSortColumn, 
             if ("desc" == self.sortOrder()){
                 return ("(descending)");
             } else {
-               return ("(ascending)");
+                return ("(ascending)");
             }
         }
         return "";
@@ -334,7 +330,7 @@ function TableItemHelper(loadItemsFunction, defaultPageSize, defaultSortColumn, 
                 Math.ceil(self.totalItemCount() / self.pageSize()) - 1);
     });
 
-   self.pages = ko.dependentObservable(function() {
+    self.pages = ko.dependentObservable(function() {
         var pages = [];
         var i;
 

--- a/octoprint_SpoolManager/templates/SpoolManager_tab.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_tab.jinja2
@@ -60,7 +60,7 @@
                                 <li>
                                     <div class="checkbox">
                                         <label>
-                                            <input type="checkbox" data-bind="checked:spoolItemTableHelper.showAllMaterialsForFilter , click:spoolItemTableHelper.doFilterSelectAll($data, 'material')"><i>select/deselect all</i>
+                                            <input type="checkbox" data-bind="checked:spoolItemTableHelper.showAllMaterialsForFilter"><i>select/deselect all</i>
                                         </label>
                                     </div>
                                 </li>
@@ -83,7 +83,7 @@
                                 <li>
                                     <div class="checkbox">
                                         <label>
-                                            <input type="checkbox" data-bind="checked:spoolItemTableHelper.showAllVendorsForFilter , click:spoolItemTableHelper.doFilterSelectAll($data, 'vendor')"><i>select/deselect all</i>
+                                            <input type="checkbox" data-bind="checked:spoolItemTableHelper.showAllVendorsForFilter"><i>select/deselect all</i>
                                         </label>
                                     </div>
                                 </li>
@@ -107,7 +107,7 @@
                                 <li>
                                     <div class="checkbox">
                                         <label>
-                                            <input type="checkbox" data-bind="checked:spoolItemTableHelper.showAllColorsForFilter , click:spoolItemTableHelper.doFilterSelectAll($data, 'color')"><i>select/deselect all</i>
+                                            <input type="checkbox" data-bind="checked:spoolItemTableHelper.showAllColorsForFilter"><i>select/deselect all</i>
                                         </label>
                                     </div>
                                 </li>


### PR DESCRIPTION
Closes #14 

Changelog:
- [x] Turn all `showAll*ForFilter` into computed values
- [x] Fix incorrectly bound `doFilterSelectAll`
- [x] Code cleanups in `TableItemHelper.js`