### PR TITLE
GH-25 | Improve delete spool ux

### DIFF
--- a/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
@@ -279,7 +279,7 @@
                         </div>
                         <!-- /ko -->
                         <div class="control-group">
-                            <label class="control-label">Serialnumber</label>
+                            <label class="control-label">Serial number</label>
                             <div class="controls">
                                 <input data-bind="textInput: spoolDialog.spoolItemForEditing.code"  type="text" class="input-large"  />
                             </div>

--- a/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
@@ -48,8 +48,16 @@
                 </span>
             </div>
             <div class="myspan8">
-                <span data-bind="visible: spoolDialog.isExistingSpool() == false"><h2>NEW </h2></span>
-                <span><h2 data-bind="text: spoolDialog.spoolItemForEditing.displayName"></h2></span>
+                <h2>
+                    <span
+                        class="label label-info"
+                        style="margin-right: 5px; font-size: inherit; line-height: inherit;"
+                        data-bind="visible: spoolDialog.isExistingSpool() == false"
+                    >
+                        NEW
+                    </span>
+                    <span data-bind="text: spoolDialog.spoolItemForEditing.displayName"></span>
+                </h2>
             </div>
 
 <!-- Customize Field visiblity

--- a/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
@@ -517,7 +517,7 @@
         </form>
     </div>
     <div class="modal-footer" >
-        <div class="control-group">
+        <div class="control-group" style="margin-bottom: 0">
             <div class="controls row-fluid">
                 <span class="span8" style="text-align:left">
 

--- a/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
@@ -524,9 +524,6 @@
                     <button type="button" class="btn btn-danger" data-bind="visible: spoolDialog.isExistingSpool,
                                                                             disable: printerStateViewModel.isPrinting(),
                                                                             click: spoolDialog.deleteSpoolItem" >Delete</button>
-                    <div data-bind="visible: printerStateViewModel.isPrinting()">
-                        <small>Deletion during printing is not possible</small>
-                    </div>
                     <button type="button" class="btn btn-warning" data-bind="visible: spoolDialog.isExistingSpool,
                                                                              click: spoolDialog.copySpoolItem" >Copy</button>
                     <!-- visible: spoolDialog.spoolItemForEditing.selectedFromQRCode() == true,                        -->
@@ -568,6 +565,9 @@
                     <button class="btn btn-info" data-bind="visible: spoolDialog.isExistingSpool()==false,
                                                             click: spoolDialog.selectAndCopyTemplateSpool" style="text-align:right">Copy from Template...</button>
 
+                    <div data-bind="visible: printerStateViewModel.isPrinting()" class="muted" style="margin-top: 10px;">
+                        <small>Deletion during printing is not possible</small>
+                    </div>
                 </span>
                 <span class="span4 text-right">
 <!--                        data-bind="click: spoolDialog.closeSpoolItemDialog"-->


### PR DESCRIPTION
Closes #25 

Changelog:
- [x] "Deletion during printing is not possible" warning no longer shifts buttons layout
- [x] Removed unnecessary bottom margin in Spool editing modal's footer
- [x] Improved "NEW" spool editing indicator
  - Easier to distinguish between actual title of the spool
  - Fixed layout shifting 