### PR TITLE
GH-34 | Update pillow to newer versions to improve plugin cross-compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Changing between each release is done via the "Software Update section" in the s
 Hint: "Easy-switching" is possible with OctoPrint-Version 1.8.0 (see https://github.com/OctoPrint/OctoPrint/issues/4238).
 At the meantime you need to uninstall and install the version you like from the selected channel...or stay in one channel ;-)
 
+## Requirements
+
+- Python 3.7+
+
 ## Versions
 
 See [Releases](https://github.com/mdziekon/OctoPrint-SpoolManager/releases/)

--- a/octoprint_SpoolManager/__init__.py
+++ b/octoprint_SpoolManager/__init__.py
@@ -934,7 +934,7 @@ class SpoolmanagerPlugin(
 # ("OctoPrint-PluginSkeleton"), you may define that here. Same goes for the other metadata derived from setup.py that
 # can be overwritten via __plugin_xyz__ control properties. See the documentation for that.
 __plugin_name__ = "SpoolManager Plugin"
-__plugin_pythoncompat__ = ">=2.7,<4"
+__plugin_pythoncompat__ = ">=3.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
 plugin_requires = [
-	"pillow >=6.2.0, <7.0.0", # since 7.0.0 no Python 2.7 Support, see https://github.com/python-pillow/Pillow/blob/master/CHANGES.rst
+	"Pillow>=9.3,<11",
 	"qrcode",
 	"peewee"
 	# "psycopg2-binary",  # postgres - driver


### PR DESCRIPTION
Closes #34 

Changelog:
- [x] `pillow` requirement bumped to at least 9.3
- [x] Python requirement bumped to at least 3.7 (Python 2 support removed)