### PR TITLE
GH-37 | Fix selecting spool by ID

### DIFF
--- a/octoprint_SpoolManager/DatabaseManager.py
+++ b/octoprint_SpoolManager/DatabaseManager.py
@@ -881,7 +881,7 @@ class DatabaseManager(object):
 
 	def loadSpool(self, databaseId, withReusedConnection=False):
 		def databaseCallMethode():
-			return SpoolModel.get_or_none(databaseId)
+			return SpoolModel.get_or_none(SpoolModel.databaseId == int(databaseId))
 
 		return self._handleReusableConnection(databaseCallMethode, withReusedConnection, "loadSpool")
 

--- a/octoprint_SpoolManager/static/js/SpoolManager.js
+++ b/octoprint_SpoolManager/static/js/SpoolManager.js
@@ -1228,6 +1228,13 @@ $(function() {
             selectedSpoolId = parseInt(selectedSpoolId);
             console.info('Loading spool: '+selectedSpoolId);
 
+            // Note: Due to OctoPrint initialization race condition
+            // (onAfterTabChange called before spools are loaded),
+            // in most cases this comparison does not work correctly.
+            // This code path is triggered only when selecting spool by QR Code via API,
+            // where the API call already selects the spool for us.
+            // TODO: Remove spool selection call from here, and instead simply show
+            // the spool edit modal. To achieve that, a "getSpoolById" API call should be added.
             const spoolCurrentToolId = self.getSpoolItemSelectedTool(selectedSpoolId);
             if (spoolCurrentToolId !== null) {
                 alert('This spool is already selected for tool ' + spoolCurrentToolId + '!');


### PR DESCRIPTION
Related to #37 

Changelog:
- [x] Fix backend "select spool by ID" method (ensure we're always comparing integers)
  - Fixes `GET /selectSpoolByQRCode/:spoolId` call, where proper redirection would be made, but API would always select spool with Id == 1 for printing
  - Fixes `GET /generateQRCodeView/:spoolId` view, where proper QR code would be generated, but invalid ID & name would be presented
- [x] Fix `SpoolManagerViewModel.onAfterTabChange` not being triggered due to its async nature
- [x] Document race condition and future work regarding selecting spools by QR code  
  - API call already does that, therefore UI duplicates this functionality
  - To move further, an additional "fetch spool by ID" API call is necessary to open up proper spool edit modal