### PR TITLE
Print QR Code Functionality

### DIFF
--- a/octoprint_SpoolManager/api/SpoolManagerAPI.py
+++ b/octoprint_SpoolManager/api/SpoolManagerAPI.py
@@ -603,11 +603,40 @@ class SpoolManagerAPI(octoprint.plugin.BlueprintPlugin):
 	def generateSpoolQRCodeHTMLView(self, databaseId):
 		htmlContent = ""
 		spoolModel = self._databaseManager.loadSpool(databaseId);
+		if spoolModel.material is None:
+			material = "N/A"
+		else:
+			material = spoolModel.material
 		if (spoolModel is not None):
 			self._logger.info("Generate HTML iew for QR-Code")
 			htmlContent = \
-						"<h3>Database Id: " + str(databaseId) + "</h3>" \
-						"<h3>Spoolname: " + spoolModel.displayName + "</h3>" \
+							"<style> " \
+							"body { "\
+							"	display: flex; " \
+							"	flex-direction: column;"\
+							"	align-items: center;"\
+							"	justify-content: center;"\
+							"	text-align: center;"\
+							"}"\
+							"img {"\
+  							"	max-width: 100%; "\
+							"}"\
+							"h2 {"\
+							"	font-size: 4em;"\
+							"}" \
+							"h3 {"\
+							"	font-size: 2em;"\
+							"}" \
+							"div {" \
+							"	margin-top: 10px;" \
+							"}" \
+						"</style> " \
+						"<div>" \
+						"<h2>Name: " + spoolModel.displayName + "</h2>" \
+						"<h2> Id: " + str(databaseId) + "</h2>" \
+						"<h3> Material: " + material + "</h3>" \
+						"<h3> Color: " + spoolModel.colorName + "</h3>" \
+						"</div>" \
 						"<img loading='lazy' src='/plugin/SpoolManager/generateQRCode/"+str(databaseId)+"' />"
 		else:
 			htmlContent = "<h3>Spool with database Id not found</h3>"

--- a/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
@@ -275,7 +275,7 @@
                                     </div>
                                     <a data-bind="attr: $root.generateQRCodeImageSourceAttribute(spoolDialog.spoolItemForEditing.databaseId(),
                                                              spoolDialog.spoolItemForEditing.displayName(),
-                                                             'htmlView')" target="_new">Print Label</a>
+                                                             'htmlView')" target="_new">Preview Label</a>
                                 </div>
                             </div>
                         </div>

--- a/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
@@ -273,7 +273,7 @@
                                     <div class="">
                                         <input title="Used for QR-Code generation" data-bind="textInput: spoolDialog.spoolItemForEditing.databaseId"  type="text" class="input-mini text-right"  disabled="true"/>
                                     </div>
-                                    <a data-bind="attr: $root.generateQRCodeImageSourceAttribute(spoolDialog.spoolItemForEditing.databaseId(),
+                                    <a class="btn btn-success" data-bind="attr: $root.generateQRCodeImageSourceAttribute(spoolDialog.spoolItemForEditing.databaseId(),
                                                              spoolDialog.spoolItemForEditing.displayName(),
                                                              'htmlView')" target="_new">Preview Label</a>
                                 </div>

--- a/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
@@ -264,9 +264,8 @@
                                                                                                          spoolDialog.spoolItemForEditing.displayName(),
                                                                                                          'htmlView')" target="_new">
                                                 <img loading="lazy" class="qr-code" alt="QR Code" data-bind="attr: $root.generateQRCodeImageSourceAttribute(spoolDialog.spoolItemForEditing.databaseId(),
-                                                                                                                                                            spoolDialog.spoolItemForEditing.displayName())">
-                                            </a>
-                                        </div>
+                                                                                                                                                            spoolDialog.spoolItemForEditing.displayName())"></a>
+                                            </div>
                                     </div>
                                 </div>
                                 <div class="span4">
@@ -274,6 +273,9 @@
                                     <div class="">
                                         <input title="Used for QR-Code generation" data-bind="textInput: spoolDialog.spoolItemForEditing.databaseId"  type="text" class="input-mini text-right"  disabled="true"/>
                                     </div>
+                                    <a data-bind="attr: $root.generateQRCodeImageSourceAttribute(spoolDialog.spoolItemForEditing.databaseId(),
+                                                             spoolDialog.spoolItemForEditing.displayName(),
+                                                             'htmlView')" target="_new">Print Label</a>
                                 </div>
                             </div>
                         </div>

--- a/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
+++ b/octoprint_SpoolManager/templates/SpoolManager_dialog_editSpool.jinja2
@@ -268,14 +268,15 @@
                                             </div>
                                     </div>
                                 </div>
-                                <div class="span4">
+                                <div class="col-md-4 d-flex align-items-center mx-auto">
                                     <label class="">Database ID</label>
                                     <div class="">
                                         <input title="Used for QR-Code generation" data-bind="textInput: spoolDialog.spoolItemForEditing.databaseId"  type="text" class="input-mini text-right"  disabled="true"/>
-                                    </div>
-                                    <a class="btn btn-success" data-bind="attr: $root.generateQRCodeImageSourceAttribute(spoolDialog.spoolItemForEditing.databaseId(),
+                                        <a class="btn btn-success btn-sm" data-bind="attr: $root.generateQRCodeImageSourceAttribute(spoolDialog.spoolItemForEditing.databaseId(),
                                                              spoolDialog.spoolItemForEditing.displayName(),
                                                              'htmlView')" target="_new">Preview Label</a>
+                                    </div>
+                                    
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
In this PR I have added a little more formatting around the generated QR code screen. Which allows for easier printing using the Dymo Label Printer. This feature was discussed here: https://github.com/mdziekon/OctoPrint-SpoolManager/issues/47. However, it is not as customizable as the feature requested. It does however offer a way for the user to print a label.

Sadly I couldn't find a good way to open the print dialog, So it's left to the user to open the print dialog in the webpage.
